### PR TITLE
Fix/solution6

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Solution6.java

--- a/.idea/OSSDP-Lab2.iml
+++ b/.idea/OSSDP-Lab2.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/L2022211817_6_Test.java
+++ b/L2022211817_6_Test.java
@@ -1,0 +1,70 @@
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class L2022211817_6_Test {
+
+    @Test
+    public void testPeopleIndexes_EmptyInput() {
+        Solution6 solution = new Solution6();
+        List<List<String>> input = Collections.emptyList();
+        List<Integer> expected = Collections.emptyList();
+        List<Integer> result = solution.peopleIndexes(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testPeopleIndexes_NoSubsets() {
+        Solution6 solution = new Solution6();
+        List<List<String>> input = Arrays.asList(
+                Arrays.asList("leetcode", "google", "facebook"),
+                Arrays.asList("amazon"),
+                Arrays.asList("microsoft")
+        );
+        List<Integer> expected = Arrays.asList(0, 1, 2);
+        List<Integer> result = solution.peopleIndexes(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testPeopleIndexes_WithSubsets() {
+        Solution6 solution = new Solution6();
+        List<List<String>> input = Arrays.asList(
+                Arrays.asList("leetcode", "google", "facebook"),
+                Arrays.asList("google", "facebook"),
+                Arrays.asList("facebook"),
+                Arrays.asList("amazon")
+        );
+        List<Integer> expected = Arrays.asList(0, 3);
+        List<Integer> result = solution.peopleIndexes(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testPeopleIndexes_AllSubsets() {
+        Solution6 solution = new Solution6();
+        List<List<String>> input = Arrays.asList(
+                Arrays.asList("leetcode"),
+                Arrays.asList("leetcode", "google"),
+                Arrays.asList("leetcode", "google", "facebook")
+        );
+        List<Integer> expected = Collections.singletonList(2);
+        List<Integer> result = solution.peopleIndexes(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testPeopleIndexes_SingleElementLists() {
+        Solution6 solution = new Solution6();
+        List<List<String>> input = Arrays.asList(
+                Arrays.asList("a"),
+                Arrays.asList("b"),
+                Arrays.asList("c")
+        );
+        List<Integer> expected = Arrays.asList(0, 1, 2);
+        List<Integer> result = solution.peopleIndexes(input);
+        assertEquals(expected, result);
+    }
+}

--- a/Solution6.java
+++ b/Solution6.java
@@ -41,43 +41,61 @@ import java.util.Set;
  * 所有字符串仅包含小写英文字母。
  *
  */
-class Solution6 {
-    Set<String>[] s = new Set[105];
-
+public class Solution6 {
     public List<Integer> peopleIndexes(List<List<String>> favoriteCompanies) {
-        for (int i = 1; i < 105; ++i) {
-            s[i] = new HashSet<String>();
-        }
-        int n = favoriteCompanies.size()-1;
-        List<Integer> ans = new ArrayList<Integer>();
-
-        for (int i = 0; i < n; ++i) {
-            for (String com : favoriteCompanies.get(i)) {
-                s[i].add(com);
-            }
-
-            for (int i = 0; i < n; ++i) {
-                boolean isSub = false;
-                for (int j = 0; j < n; ++j) {
-                    if (i == j) {
-                        continue;
-                    }
-                    isSub |= check(favoriteCompanies, i, j);
-                }
-                if (isSub) {
-                    ans.add(i);
-                }
-            }
-
-            return ans;
+        List<Set<String>> sets = new ArrayList<>();
+        // 将每个用户的公司清单转换为HashSet，以便进行子集检查
+        for (List<String> list : favoriteCompanies) {
+            sets.add(new HashSet<>(list));
         }
 
-        public boolean check(List<List<String>> favoriteCompanies, int x, int y) {
-            for (String com : favoriteCompanies.get(x)) {
-                if (!s[y].contains(com)) {
-                    return false;
+        List<Integer> ans = new ArrayList<>();
+        // 逐个检查每个HashSet是否是其他HashSet的子集
+        for (int i = 0; i < sets.size(); i++) {
+            boolean isSubset = false;
+            for (int j = 0; j < sets.size(); j++) {
+                if (i != j && sets.get(j).containsAll(sets.get(i))) {
+                    // 注意这里是检查sets.get(i)是否是sets.get(j)的子集
+                    // 如果sets.get(i)是sets.get(j)的子集，则标记为isSubset = true并退出内层循环
+                    isSubset = true;
+                    break;
                 }
             }
-            return true;
+            // 如果当前HashSet不是任何其他HashSet的子集，则添加到结果列表中
+            if (!isSubset) {
+                ans.add(i);
+            }
         }
+
+        return ans;
     }
+
+    // 测试类
+    public static void main(String[] args) {
+        Solution6 solution = new Solution6();
+
+        // 测试用例1
+        List<List<String>> favoriteCompanies1 = new ArrayList<>();
+        favoriteCompanies1.add(List.of("leetcode", "google", "facebook"));
+        favoriteCompanies1.add(List.of("google", "microsoft"));
+        favoriteCompanies1.add(List.of("google", "facebook"));
+        favoriteCompanies1.add(List.of("google"));
+        favoriteCompanies1.add(List.of("amazon"));
+        System.out.println("Test case 1: " + solution.peopleIndexes(favoriteCompanies1)); // Output: [0, 1, 4]
+
+        // 测试用例2
+        List<List<String>> favoriteCompanies2 = new ArrayList<>();
+        favoriteCompanies2.add(List.of("leetcode", "google", "facebook"));
+        favoriteCompanies2.add(List.of("leetcode", "amazon"));
+        favoriteCompanies2.add(List.of("facebook", "google"));
+        System.out.println("Test case 2: " + solution.peopleIndexes(favoriteCompanies2)); // Output: [0, 1]
+
+        // 测试用例3
+        List<List<String>> favoriteCompanies3 = new ArrayList<>();
+        favoriteCompanies3.add(List.of("leetcode"));
+        favoriteCompanies3.add(List.of("google"));
+        favoriteCompanies3.add(List.of("facebook"));
+        favoriteCompanies3.add(List.of("amazon"));
+        System.out.println("Test case 3: " + solution.peopleIndexes(favoriteCompanies3)); // Output: [0, 1, 2, 3]
+    }
+}

--- a/production/OSSDP-Lab2/.idea/.gitignore
+++ b/production/OSSDP-Lab2/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/production/OSSDP-Lab2/.idea/.name
+++ b/production/OSSDP-Lab2/.idea/.name
@@ -1,0 +1,1 @@
+Solution6.java

--- a/production/OSSDP-Lab2/.idea/OSSDP-Lab2.iml
+++ b/production/OSSDP-Lab2/.idea/OSSDP-Lab2.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/production/OSSDP-Lab2/.idea/compiler.xml
+++ b/production/OSSDP-Lab2/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/.idea/misc.xml
+++ b/production/OSSDP-Lab2/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/.idea/modules.xml
+++ b/production/OSSDP-Lab2/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/production/OSSDP-Lab2/.idea/vcs.xml
+++ b/production/OSSDP-Lab2/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/README.md
+++ b/production/OSSDP-Lab2/README.md
@@ -1,0 +1,1 @@
+# OSSDP-Lab2

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/.gitignore
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/.name
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/.name
@@ -1,0 +1,1 @@
+Solution6.java

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/OSSDP-Lab2.iml
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/OSSDP-Lab2.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/compiler.xml
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/misc.xml
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/modules.xml
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/vcs.xml
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/production/OSSDP-Lab2/production/OSSDP-Lab2/README.md
+++ b/production/OSSDP-Lab2/production/OSSDP-Lab2/README.md
@@ -1,0 +1,1 @@
+# OSSDP-Lab2


### PR DESCRIPTION
2022211817
正确初始化并存储收藏清单：为每个用户的收藏清单创建一个HashSet，而不是使用一个静态数组。
调整循环逻辑：内部循环和返回语句的位置需要调整，以确保在检查完所有用户的收藏清单后再返回结果。
简化子集检查：直接在check方法中比较两个HashSet是否满足子集关系，而不需要再遍历所有字符串。